### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -22,11 +28,12 @@
       "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,8 +47,16 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/npm"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the hassio-addons org. Every `alpine_3_24/*` lookup returns `no-result`, so the Alpine pins in the Dockerfile are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and every run resolves all of our pins through it.

This replaces it with a custom datasource that reads the Alpine CDN directory listings directly:

* A `custom.alpine` datasource in `format: "html"`, pointed at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/`. Renovate turns every `href` in that listing (`nginx-1.30.4-r1.apk`) into a version candidate, and the new `extractVersionTemplate` pulls the version back out of the filename.
* One package rule that points `npm` at the `community/x86_64/` listing. Custom datasources use `registryStrategy: "first"`, so multiple `registryUrls` are not hunted and community packages would otherwise fail to resolve. `npm` is the only pin in this repository that does not live in `main`.
* The existing `repology` package rule now matches `custom.alpine`.

One extra fix while in here: the package capture group was `[a-z0-9-]+`, which also matched the `--omit=dev` flag of the `npm install` invocation in the Dockerfile and turned it into a bogus `alpine_3_24/--omit` dependency. It is now `[a-z0-9][a-z0-9-_]+`, matching the pattern already used in the other app repositories.

### Verification

A passing CI build proves nothing for this change: it does not touch the Dockerfile, so buildx serves the `apk` layer from cache and no `apk add` runs. This was verified with a local Renovate dry run instead (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup`, `ghcr.io/renovatebot/renovate:latest`):

* `renovate-config-validator` passes.
* All 5 Alpine pins in `zwave-js-ui/Dockerfile` are extracted and resolved: `eudev`, `libusb`, `nginx`, `nodejs` (main) and `npm` (community, resolved through the community registry URL). That is exactly the number of pins in the Dockerfile, with no bogus `--omit` entry any more.
* Zero lookup failures in the debug log (`grep -c "Found no results"` is 0).
* No updates are reported, and that is correct: cross-checking every pin against the `main` and `community` `APKINDEX` files shows all five already match the current Alpine v3.24 version, so there are no stale pins in this repository blocking anything.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Same change as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic detection of Alpine Linux package updates.
  * Added support for matching package names containing underscores.
  * Enhanced version detection from Alpine package filenames.
  * Continued automatic merging for compatible Alpine dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->